### PR TITLE
Fix installing cryptography by updating pip

### DIFF
--- a/.github/workflows/ansible-test-deploy.yml
+++ b/.github/workflows/ansible-test-deploy.yml
@@ -41,9 +41,12 @@ jobs:
           Add-LocalGroupMember -Group Administrators -Member Ansible
           Enable-LocalUser -Name "Ansible"
         shell: powershell
+      - name: Update pip and setuptools
+        shell: msys2 {0}
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip cryptography==3.3.2 wheel install ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -46,7 +46,7 @@ jobs:
         shell: powershell
       - name: Update pip
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install –upgrade pip
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip
       - name: Install Ansible
         shell: msys2 {0}
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
+          install: base-devel git gcc msys2-devel python3 python3-pip libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
       - name: Download ConfigureRemotingForAnsible.ps1
         run: wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -Outfile ConfigureRemotingForAnsible.ps1
         shell: powershell

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
+          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel
       - name: Download ConfigureRemotingForAnsible.ps1
         run: wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -Outfile ConfigureRemotingForAnsible.ps1
         shell: powershell
@@ -46,10 +46,10 @@ jobs:
         shell: powershell
       - name: Update pip and setuptools
         shell: msys2 {0}
-        run: python -m pip install --upgrade pip setuptools
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: python -m pip install --verbose wheel setuptools-rust ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install cryptography=3.3.2 wheel setuptools-rust ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install setuptools-rust ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install wheel setuptools-rust ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -44,6 +44,9 @@ jobs:
           Add-LocalGroupMember -Group Administrators -Member Ansible
           Enable-LocalUser -Name "Ansible"
         shell: powershell
+      - name: Update pip
+        shell: msys2 {0}
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install –upgrade pip
       - name: Install Ansible
         shell: msys2 {0}
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install setuptools-rust ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-python-cryptography
+          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
       - name: Download ConfigureRemotingForAnsible.ps1
         run: wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -Outfile ConfigureRemotingForAnsible.ps1
         shell: powershell
@@ -44,9 +44,9 @@ jobs:
           Add-LocalGroupMember -Group Administrators -Member Ansible
           Enable-LocalUser -Name "Ansible"
         shell: powershell
-      - name: Update pip
+      - name: Update pip and setuptools
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel
+          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
       - name: Download ConfigureRemotingForAnsible.ps1
         run: wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -Outfile ConfigureRemotingForAnsible.ps1
         shell: powershell

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install cryptography=3.3.2 wheel setuptools-rust ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install cryptography==3.3.2 wheel setuptools-rust ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
+          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-python-cryptography
       - name: Download ConfigureRemotingForAnsible.ps1
         run: wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -Outfile ConfigureRemotingForAnsible.ps1
         shell: powershell

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel git gcc msys2-devel python3 python3-pip libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
+          install: base-devel git gcc msys2-devel python3 python3-pip libffi libffi-devel libcrypt libcrypt-devel openssl openssl-devel mingw-w64-x86_64-rust
       - name: Download ConfigureRemotingForAnsible.ps1
         run: wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -Outfile ConfigureRemotingForAnsible.ps1
         shell: powershell

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install wheel setuptools-rust ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --verbose wheel setuptools-rust ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -46,10 +46,10 @@ jobs:
         shell: powershell
       - name: Update pip and setuptools
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --upgrade pip setuptools
+        run: python -m pip install --upgrade pip setuptools
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install --verbose wheel setuptools-rust ansible pywinrm
+        run: python -m pip install --verbose wheel setuptools-rust ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |


### PR DESCRIPTION
Fix pipelines Ansible installation by updating pip. Rust compiler is now necessary to build cryptography python package. Or update pip to latest version that does provide precompiled wheel.